### PR TITLE
Integrate help description.

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,9 @@ vorpal
 // Load Ascii birds art
 ascii_art.birds();
 
+// Integrate help description.
+vorpal.find('help').description('Exits lovebird.');
+
 // Execute REPL
 vorpal
     .delimiter(chalk.bold.green('lovebird$'))


### PR DESCRIPTION
Looks a little silly / confusing to say `Exits instance of Vorpal.` on the help description. Changed the description.
